### PR TITLE
Add "Create a List" method

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -130,6 +130,7 @@ extension Twift {
     case removeListMember(_ listId: List.ID, userId: User.ID)
     case userFollowingLists(_ userId: User.ID, listId: List.ID? = nil)
     case userPinnedLists(_ userId: User.ID, listId: List.ID? = nil)
+    case createList
     
     case spaces(_ id: Space.ID? = nil, subpath: Space.APISubpath? = nil)
     case searchSpaces
@@ -235,7 +236,8 @@ extension Twift {
         } else {
           return (path: "/2/users/\(userId)/pinned_lists", queryItems: nil)
         }
-        
+      case .createList:
+          return (path: "/2/lists/", queryItems: nil)
       case .userFollowingLists(let userId, let listId):
         if let listId = listId {
           return (path: "/2/users/\(userId)/followed_lists/\(listId)", queryItems: nil)

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -237,7 +237,7 @@ extension Twift {
           return (path: "/2/users/\(userId)/pinned_lists", queryItems: nil)
         }
       case .createList:
-          return (path: "/2/lists/", queryItems: nil)
+          return (path: "/2/lists", queryItems: nil)
       case .userFollowingLists(let userId, let listId):
         if let listId = listId {
           return (path: "/2/users/\(userId)/followed_lists/\(listId)", queryItems: nil)

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -123,6 +123,15 @@ extension Twift {
                               body: serializedBody,
                               expectedReturnType: TwitterAPIData.self)
     }
+    
+    /// A response object pertaining to list created
+    /// - Returns:
+    ///  - id: If the returned response object contains an id, response is considered successfull
+    ///  - name: If List name was returned, response is considered successfull
+    public struct CreatedListResponse: Codable {
+        public let id: Int
+        public let name: String
+    }
 }
 
 extension Twift {

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -110,12 +110,12 @@ extension Twift {
     ///  - description: Description for the list (optional)
     ///  - private: Whether created list is private and viewable only by the authenticated user or publicly viewable
     /// - Returns: A response object containing the name and the ID of the list.
-    public func createList(name: String, description: String? = "", isPrivate: Bool? = false) async throws -> TwitterAPIData<CreatedListResponse> {
+    public func createList(name: String, description: String? = "", isPrivate: Bool = false) async throws -> TwitterAPIData<CreatedListResponse> {
         
         let body: [String : Any] = [
             "name": name,
             "description": description ?? "",
-            "private": isPrivate ?? false
+            "private": isPrivate
         ]
         let serializedBody = try JSONSerialization.data(withJSONObject: body)
         return try await call(route: .createList,

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -399,6 +399,6 @@ public struct PinnedResponse: Codable {
 public struct CreatedListResponse: Codable {
     /// The ID for the newly-created List
     public let id: List.ID
-    /// If List name was returned, response is considered successfull
+    /// The name for the newly-created List
     public let name: String
 }

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -397,7 +397,7 @@ public struct PinnedResponse: Codable {
 
 /// A response object pertaining to list created
 public struct CreatedListResponse: Codable {
-    /// If returned response object contains an id, response is considered successfull
+    /// The ID for the newly-created List
     public let id: Int
     /// If List name was returned, response is considered successfull
     public let name: String

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -103,6 +103,23 @@ extension Twift {
   public func deleteList(_ listId: List.ID) async throws -> TwitterAPIData<DeleteResponse> {
     return try await call(route: .list(listId), method: .DELETE, expectedReturnType: TwitterAPIData.self)
   }
+    
+    /// Enables the authenticated user to delete a List that they own.
+    /// - Parameter listId: The ID of the List to be deleted.
+    /// - Returns: A response object containing the result of the delete request
+    public func createList(name: String, description: String? = "", isPrivate: Bool? = false) async throws -> TwitterAPIData<CreatedListResponse> {
+        
+        let body: [String : Any] = [
+            "name": name,
+            "description": description ?? "",
+            "private": isPrivate ?? false
+        ]
+        let serializedBody = try JSONSerialization.data(withJSONObject: body)
+        return try await call(route: .createList,
+                              method: .POST,
+                              body: serializedBody,
+                              expectedReturnType: TwitterAPIData.self)
+    }
 }
 
 extension Twift {

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -108,7 +108,7 @@ extension Twift {
     /// - Parameters:
     ///  - name: List name (required)
     ///  - description: Description for the list (optional)
-    ///  - private: true or false (optional)
+    ///  - private: Whether created list is private and viewable only by the authenticated user or publicly viewable
     /// - Returns: A response object containing the name and the ID of the list.
     public func createList(name: String, description: String? = "", isPrivate: Bool? = false) async throws -> TwitterAPIData<CreatedListResponse> {
         

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -105,6 +105,8 @@ extension Twift {
   }
     
     /// Enables the authenticated user to create a new List.
+    ///
+    /// Equivalent to `POST /2/lists`
     /// - Parameters:
     ///  - name: List name (required)
     ///  - description: Description for the list (optional)

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -398,7 +398,7 @@ public struct PinnedResponse: Codable {
 /// A response object pertaining to list created
 public struct CreatedListResponse: Codable {
     /// The ID for the newly-created List
-    public let id: Int
+    public let id: List.ID
     /// If List name was returned, response is considered successfull
     public let name: String
 }

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -124,14 +124,6 @@ extension Twift {
                               expectedReturnType: TwitterAPIData.self)
     }
     
-    /// A response object pertaining to list created
-    /// - Returns:
-    ///  - id: If the returned response object contains an id, response is considered successfull
-    ///  - name: If List name was returned, response is considered successfull
-    public struct CreatedListResponse: Codable {
-        public let id: Int
-        public let name: String
-    }
 }
 
 extension Twift {
@@ -399,4 +391,12 @@ extension Twift {
 public struct PinnedResponse: Codable {
   /// Indicates whether the user pinned the specified List as a result of the request.
   public let pinned: Bool
+}
+
+/// A response object pertaining to list created
+public struct CreatedListResponse: Codable {
+    /// If returned response object contains an id, response is considered successfull
+    public let id: Int
+    /// If List name was returned, response is considered successfull
+    public let name: String
 }

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -104,9 +104,12 @@ extension Twift {
     return try await call(route: .list(listId), method: .DELETE, expectedReturnType: TwitterAPIData.self)
   }
     
-    /// Enables the authenticated user to delete a List that they own.
-    /// - Parameter listId: The ID of the List to be deleted.
-    /// - Returns: A response object containing the result of the delete request
+    /// Enables the authenticated user to create a new List.
+    /// - Parameters:
+    ///  - name: List name (required)
+    ///  - description: Description for the list (optional)
+    ///  - private: true or false (optional)
+    /// - Returns: A response object containing the name and the ID of the list.
     public func createList(name: String, description: String? = "", isPrivate: Bool? = false) async throws -> TwitterAPIData<CreatedListResponse> {
         
         let body: [String : Any] = [

--- a/Sources/Twift+Tweets.swift
+++ b/Sources/Twift+Tweets.swift
@@ -262,13 +262,6 @@ public struct DeleteResponse: Codable {
   public let deleted: Bool
 }
 
-/// A response object pertaining to list created
-public struct CreatedListResponse: Codable {
-    /// If the returned response object contains an id and the name of your List, you have successfully created the List.
-    public let id: Int
-    public let name: String
-}
-
 extension Twift {
   // MARK: Hide/Unhide Tweets
   internal func toggleHiddenTweet(_ id: Tweet.ID, hidden: Bool) async throws -> TwitterAPIData<HiddenResponse> {

--- a/Sources/Twift+Tweets.swift
+++ b/Sources/Twift+Tweets.swift
@@ -262,6 +262,13 @@ public struct DeleteResponse: Codable {
   public let deleted: Bool
 }
 
+/// A response object pertaining to list created
+public struct CreatedListResponse: Codable {
+    /// If the returned response object contains an id and the name of your List, you have successfully created the List.
+    public let id: Int
+    public let name: String
+}
+
 extension Twift {
   // MARK: Hide/Unhide Tweets
   internal func toggleHiddenTweet(_ id: Tweet.ID, hidden: Bool) async throws -> TwitterAPIData<HiddenResponse> {


### PR DESCRIPTION
Create List method was lacking from the "Manage Lists" group.
https://developer.twitter.com/en/docs/twitter-api/lists/manage-lists/introduction

Not sure If this is the correct way to do it, but I tried to follow the same approach as for some other similar methods I saw inside Twift.

@daneden Note 👇
The main concern on my end is: "How do I test this?" 😅
So far I've only worked on personal packages and changing branches was easy 👌 However, when contributing I do not know how to test it without having to do quite a bit of duplication 😅