### PR TITLE
Add Bookmarks API support

### DIFF
--- a/Demo App/Twift_SwiftUI.xcodeproj/project.pbxproj
+++ b/Demo App/Twift_SwiftUI.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		7157CD1527F303D900324A43 /* PaginatedTweetsMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7157CD1427F303D900324A43 /* PaginatedTweetsMethodView.swift */; };
 		7157CD1727F3127C00324A43 /* PaginatedUsersMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7157CD1627F3127C00324A43 /* PaginatedUsersMethodView.swift */; };
 		716FADEC27F0B82A002C1BA1 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 716FADEB27F0B82A002C1BA1 /* README.md */; };
+		71D1487327F99201001E3F7A /* GetBookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D1487227F99201001E3F7A /* GetBookmarks.swift */; };
+		71D1487527F99481001E3F7A /* AddBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D1487427F99481001E3F7A /* AddBookmark.swift */; };
+		71D1487727F99593001E3F7A /* DeleteBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D1487627F99593001E3F7A /* DeleteBookmark.swift */; };
 		71D283EF279DAD5F00640B2A /* PostTweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D283EE279DAD5F00640B2A /* PostTweet.swift */; };
 /* End PBXBuildFile section */
 
@@ -97,6 +100,9 @@
 		7157CD1427F303D900324A43 /* PaginatedTweetsMethodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedTweetsMethodView.swift; sourceTree = "<group>"; };
 		7157CD1627F3127C00324A43 /* PaginatedUsersMethodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedUsersMethodView.swift; sourceTree = "<group>"; };
 		716FADEB27F0B82A002C1BA1 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		71D1487227F99201001E3F7A /* GetBookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBookmarks.swift; sourceTree = "<group>"; };
+		71D1487427F99481001E3F7A /* AddBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBookmark.swift; sourceTree = "<group>"; };
+		71D1487627F99593001E3F7A /* DeleteBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteBookmark.swift; sourceTree = "<group>"; };
 		71D283EE279DAD5F00640B2A /* PostTweet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTweet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -223,6 +229,9 @@
 				714749EB2796079400CB128B /* UserMentions.swift */,
 				714749E52794A8E000CB128B /* UserTimeline.swift */,
 				714749E72795B45F00CB128B /* VolumeStream.swift */,
+				71D1487227F99201001E3F7A /* GetBookmarks.swift */,
+				71D1487427F99481001E3F7A /* AddBookmark.swift */,
+				71D1487627F99593001E3F7A /* DeleteBookmark.swift */,
 			);
 			path = Tweets;
 			sourceTree = "<group>";
@@ -329,6 +338,7 @@
 				71242AAE27918311000372DE /* Users.swift in Sources */,
 				712BF229278F1C02006CB2F2 /* Twift_SwiftUIApp.swift in Sources */,
 				71242ABA2791B624000372DE /* GetUsersByUsernames.swift in Sources */,
+				71D1487727F99593001E3F7A /* DeleteBookmark.swift in Sources */,
 				714749F027980EDC00CB128B /* UserLikes.swift in Sources */,
 				710AAC9927F3552C00427266 /* CreateList.swift in Sources */,
 				7157CD1527F303D900324A43 /* PaginatedTweetsMethodView.swift in Sources */,
@@ -345,6 +355,7 @@
 				714749D2279340B600CB128B /* GetMutedUsers.swift in Sources */,
 				710AAC9C27F3561900427266 /* Lists.swift in Sources */,
 				714749F42799DA2C00CB128B /* PhotoPicker.swift in Sources */,
+				71D1487527F99481001E3F7A /* AddBookmark.swift in Sources */,
 				71242ABE2791D244000372DE /* AsyncButton.swift in Sources */,
 				71242AC62791F69C000372DE /* FollowUser.swift in Sources */,
 				71242ABC2791D140000372DE /* UserRow.swift in Sources */,
@@ -354,6 +365,7 @@
 				714749EC2796079400CB128B /* UserMentions.swift in Sources */,
 				71242AC22791F30C000372DE /* GetFollowers.swift in Sources */,
 				714749F62799DA5100CB128B /* UploadMedia.swift in Sources */,
+				71D1487327F99201001E3F7A /* GetBookmarks.swift in Sources */,
 				714749CA2793320400CB128B /* BlockUser.swift in Sources */,
 				71242AB12791839F000372DE /* GetUser.swift in Sources */,
 				7157CD1727F3127C00324A43 /* PaginatedUsersMethodView.swift in Sources */,

--- a/Demo App/Twift_SwiftUI.xcodeproj/project.pbxproj
+++ b/Demo App/Twift_SwiftUI.xcodeproj/project.pbxproj
@@ -220,6 +220,9 @@
 		714749D927934B0E00CB128B /* Tweets */ = {
 			isa = PBXGroup;
 			children = (
+				71D1487427F99481001E3F7A /* AddBookmark.swift */,
+				71D1487627F99593001E3F7A /* DeleteBookmark.swift */,
+				71D1487227F99201001E3F7A /* GetBookmarks.swift */,
 				714749DA27934B1A00CB128B /* GetTweet.swift */,
 				714749ED27960BBC00CB128B /* LikeTweet.swift */,
 				71D283EE279DAD5F00640B2A /* PostTweet.swift */,
@@ -229,9 +232,6 @@
 				714749EB2796079400CB128B /* UserMentions.swift */,
 				714749E52794A8E000CB128B /* UserTimeline.swift */,
 				714749E72795B45F00CB128B /* VolumeStream.swift */,
-				71D1487227F99201001E3F7A /* GetBookmarks.swift */,
-				71D1487427F99481001E3F7A /* AddBookmark.swift */,
-				71D1487627F99593001E3F7A /* DeleteBookmark.swift */,
 			);
 			path = Tweets;
 			sourceTree = "<group>";

--- a/Demo App/Twift_SwiftUI/Tweets/AddBookmark.swift
+++ b/Demo App/Twift_SwiftUI/Tweets/AddBookmark.swift
@@ -1,0 +1,43 @@
+//
+//  AddBookmark.swift
+//  Twift_SwiftUI
+//
+//  Created by Daniel Eden on 17/01/2022.
+//
+
+import SwiftUI
+import Twift
+
+struct AddBookmark: View {
+  @EnvironmentObject var twitterClient: Twift
+  @State var response: BookmarkResponse?
+  @SceneStorage("tweetId") var tweetId = ""
+  @SceneStorage("userId") var userId = ""
+  
+  var body: some View {
+    Form {
+      Section {
+        TextField("Tweet ID", text: $tweetId)
+        TextField("User ID", text: $userId)
+        AsyncButton {
+          do {
+            let result = try await twitterClient.addBookmark(tweetId, userId: userId)
+            response = result.data
+          } catch {
+            print(error)
+          }
+        } label: {
+          Text("Add Bookmark")
+        }.disabled(tweetId.isEmpty || userId.isEmpty)
+      }
+      
+      Text(String(reflecting: response))
+    }
+  }
+}
+
+struct AddBookmark_Previews: PreviewProvider {
+  static var previews: some View {
+    AddBookmark()
+  }
+}

--- a/Demo App/Twift_SwiftUI/Tweets/DeleteBookmark.swift
+++ b/Demo App/Twift_SwiftUI/Tweets/DeleteBookmark.swift
@@ -1,0 +1,43 @@
+//
+//  DeleteBookmark.swift
+//  Twift_SwiftUI
+//
+//  Created by Daniel Eden on 17/01/2022.
+//
+
+import SwiftUI
+import Twift
+
+struct DeleteBookmark: View {
+  @EnvironmentObject var twitterClient: Twift
+  @State var response: BookmarkResponse?
+  @SceneStorage("tweetId") var tweetId = ""
+  @SceneStorage("userId") var userId = ""
+  
+  var body: some View {
+    Form {
+      Section {
+        TextField("Tweet ID", text: $tweetId)
+        TextField("User ID", text: $userId)
+        AsyncButton {
+          do {
+            let result = try await twitterClient.deleteBookmark(tweetId, userId: userId)
+            response = result.data
+          } catch {
+            print(error)
+          }
+        } label: {
+          Text("Delete Bookmark")
+        }.disabled(tweetId.isEmpty || userId.isEmpty)
+      }
+      
+      Text(String(reflecting: response))
+    }
+  }
+}
+
+struct DeleteBookmark_Previews: PreviewProvider {
+  static var previews: some View {
+    DeleteBookmark()
+  }
+}

--- a/Demo App/Twift_SwiftUI/Tweets/GetBookmarks.swift
+++ b/Demo App/Twift_SwiftUI/Tweets/GetBookmarks.swift
@@ -1,14 +1,14 @@
 //
-//  UserTimeline.swift
+//  GetBookmarks.swift
 //  Twift_SwiftUI
 //
-//  Created by Daniel Eden on 16/01/2022.
+//  Created by Daniel Eden on 03/04/2022.
 //
 
 import SwiftUI
 import Twift
 
-struct UserTimeline: PagedView {
+struct GetBookmarks: PagedView {
   @EnvironmentObject var twitterClient: Twift
   @State var tweets: [Tweet]?
   @State var errors: [TwitterAPIError] = []
@@ -17,27 +17,27 @@ struct UserTimeline: PagedView {
   
   @SceneStorage("userId") var userId = ""
   
-    var body: some View {
-      Form {
-        Section {
-          TextField("User ID", text: $userId)
-            .keyboardType(.numberPad)
-          
-          AsyncButton(action: {
-            await getPage(nil)
-          }) {
-            Text("Get user timeline")
-          }
+  var body: some View {
+    Form {
+      Section {
+        TextField("User ID", text: $userId)
+          .keyboardType(.numberPad)
+        
+        AsyncButton(action: {
+          await getPage(nil)
+        }) {
+          Text("Get bookmarks")
         }
-        
-        PaginatedTweetsMethodView(tweets: tweets,
-                                  errors: errors,
-                                  includes: includes,
-                                  meta: meta,
-                                  getPage: getPage)
-        
-      }.navigationTitle("Get User Timeline")
-    }
+      }
+      
+      PaginatedTweetsMethodView(tweets: tweets,
+                                errors: errors,
+                                includes: includes,
+                                meta: meta,
+                                getPage: getPage)
+      
+    }.navigationTitle("Get Bookmarks")
+  }
   
   func userForTweet(tweet: Tweet) -> User? {
     guard let authorId = tweet.authorId else { return nil }
@@ -47,8 +47,8 @@ struct UserTimeline: PagedView {
   
   func getPage(_ token: String?) async {
     do {
-      let result = try await twitterClient.userTimeline(
-        userId,
+      let result = try await twitterClient.getBookmarks(
+        for: userId,
         fields: Set(Tweet.publicFields),
         expansions: [.authorId(userFields: [\.profileImageUrl])],
         paginationToken: token
@@ -70,8 +70,8 @@ struct UserTimeline: PagedView {
   }
 }
 
-struct UserTimeline_Previews: PreviewProvider {
-    static var previews: some View {
-        UserTimeline()
-    }
+struct GetBookmarks_Previews: PreviewProvider {
+  static var previews: some View {
+    GetBookmarks()
+  }
 }

--- a/Demo App/Twift_SwiftUI/Tweets/Tweets.swift
+++ b/Demo App/Twift_SwiftUI/Tweets/Tweets.swift
@@ -31,6 +31,12 @@ struct Tweets: View {
           NavigationLink(destination: UserLikes()) { MethodRow(label: "`getUserLikes(for userId)`", method: .GET) }
         }
         
+        Section("Bookmarks") {
+          NavigationLink(destination: GetBookmarks()) { MethodRow(label: "`getBookmarks(for userId)`", method: .GET) }
+          NavigationLink(destination: AddBookmark()) { MethodRow(label: "`addBookmark(_ tweetId, userId)`", method: .POST) }
+          NavigationLink(destination: DeleteBookmark()) { MethodRow(label: "`deleteBookmark(_ tweetId, userId)`", method: .DELETE) }
+        }
+        
         Section {
           NavigationLink(destination: VolumeStream()) { MethodRow(label: "`volumeStream()`", method: .GET) }
         } header: {

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -148,6 +148,9 @@ extension Twift {
     
     case mediaMetadataCreate
     
+    case bookmarks(_ userId: User.ID)
+    case deleteBookmark(userId: User.ID, tweetId: Tweet.ID)
+    
     var resolvedPath: (path: String, queryItems: [URLQueryItem]?) {
       switch self {
       case .tweet(let id):
@@ -272,6 +275,11 @@ extension Twift {
         
       case .mediaMetadataCreate:
         return (path: "/1.1/media/metadata/create.json", queryItems: nil)
+        
+      case .bookmarks(let userId):
+        return (path: "/2/users/\(userId)/bookmarks", queryItems: nil)
+      case .deleteBookmark(let userId, let tweetId):
+        return (path: "/2/users/\(userId)/bookmarks/\(tweetId)", queryItems: nil)
       }
     }
   }

--- a/Sources/Twift+Bookmarks.swift
+++ b/Sources/Twift+Bookmarks.swift
@@ -41,4 +41,40 @@ extension Twift {
                           queryItems: queryItems + fieldsAndExpansions,
                           expectedReturnType: TwitterAPIDataIncludesAndMeta.self)
   }
+  
+  /// Causes the user ID of an authenticated user identified in the path parameter to Bookmark the target Tweet
+  ///
+  /// Equivalent to `POST /2/users/:id/bookmarks`
+  /// - Parameters:
+  ///   - tweetId: The ID of the Tweet that you would like the `userId` to Bookmark.
+  ///   - userId: The user ID who you are liking a Tweet on behalf of. It must match your own user ID or that of an authenticating user. When set to `nil`, this method will try to use the currently-authenticated user's ID.
+  /// - Returns: A response object containing a ``BookmarkResponse``
+  public func addBookmark(_ tweetId: Tweet.ID, userId: User.ID) async throws -> TwitterAPIData<BookmarkResponse> {
+    let body = ["tweet_id": tweetId]
+    let encodedBody = try JSONSerialization.data(withJSONObject: body, options: [])
+    
+    return try await call(route: .bookmarks(userId),
+                          method: .POST,
+                          body: encodedBody,
+                          expectedReturnType: TwitterAPIData.self)
+  }
+  
+  /// Allows a user or authenticated user ID to remove a Bookmark of a Tweet.
+  ///
+  /// Equivalent to `DELETE /2/users/:user_id/bookmarks/:tweet_id`
+  /// - Parameters:
+  ///   - tweetId: The ID of the Tweet that you would like the `userId` to unlike.
+  ///   - userId: The user ID who you are removing Like of a Tweet on behalf of. It must match your own user ID or that of an authenticating user. When set to `nil`, this method will try to use the currently-authenticated user's ID.
+  /// - Returns: A response object containing a ``BookmarkResponse``
+  public func deleteBookmark(_ tweetId: Tweet.ID, userId: User.ID) async throws -> TwitterAPIData<BookmarkResponse> {
+    return try await call(route: .deleteBookmark(userId: userId, tweetId: tweetId),
+                          method: .DELETE,
+                          expectedReturnType: TwitterAPIData.self)
+  }
+}
+
+/// A response object containing information relating to Bookmark-related API requests
+public struct BookmarkResponse: Codable {
+  /// Indicates whether the user bookmarked the specified Tweet as a result of this request.
+  let bookmarked: Bool
 }

--- a/Sources/Twift+Bookmarks.swift
+++ b/Sources/Twift+Bookmarks.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Daniel Eden on 26/03/2022.
+//
+
+import Foundation
+
+extension Twift {
+  /// Allows you to get an authenticated user's 800 most recent bookmarked Tweets.
+  ///
+  /// Equivalent to `GET /2/users/:id/bookmarks`
+  /// - Parameters:
+  ///   - userId: User ID of an authenticated user to request bookmarked Tweets for.
+  ///   - fields: Any additional fields to include on returned objects
+  ///   - expansions: Objects and their corresponding fields that should be expanded in the `includes` property
+  ///   - paginationToken: When iterating over pages of results, you can pass in the `nextToken` from the previously-returned value to get the next page of results
+  ///   - maxResults: The maximum number of results to fetch.
+  /// - Returns: A Twitter API response object containing an array of ``Tweet`` structs representing the authenticated user's bookmarked Tweets
+  public func getBookmarks(for userId: User.ID? = nil,
+                           fields: Set<Tweet.Field> = [],
+                           expansions: [Tweet.Expansions] = [],
+                           paginationToken: String? = nil,
+                           maxResults: Int = 10
+  ) async throws -> TwitterAPIDataIncludesAndMeta<[Tweet], Tweet.Includes, Meta> {
+    guard let userId = userId ?? authenticatedUserId else { throw TwiftError.MissingUserID }
+    
+    switch maxResults {
+    case 1...100:
+      break
+    default:
+      throw TwiftError.RangeOutOfBoundsError(min: 1, max: 100, fieldName: "maxResults", actual: maxResults)
+    }
+    var queryItems = [URLQueryItem(name: "max_results", value: "\(maxResults)")]
+    if let paginationToken = paginationToken { queryItems.append(URLQueryItem(name: "pagination_token", value: paginationToken)) }
+    
+    let fieldsAndExpansions = fieldsAndExpansions(for: Tweet.self, fields: fields, expansions: expansions)
+    
+    return try await call(route: .bookmarks(userId),
+                          queryItems: queryItems + fieldsAndExpansions,
+                          expectedReturnType: TwitterAPIDataIncludesAndMeta.self)
+  }
+}


### PR DESCRIPTION
Adds bookmarks API support. The bookmarks API requires OAuth 2.0 PKCE authentication, which isn’t yet supported in Twift. A separate PR will likely be opened to add this support!