### PR TITLE
Add OAuth 2.0 user authentication

### DIFF
--- a/Demo App/Twift_SwiftUI/Tweets/PostTweet.swift
+++ b/Demo App/Twift_SwiftUI/Tweets/PostTweet.swift
@@ -27,12 +27,15 @@ struct PostTweet: View {
         
         AsyncButton {
           do {
-            let media = MutableMedia(mediaIds: [mediaKey])
+            let media = mediaKey.isEmpty ? nil : MutableMedia(mediaIds: [mediaKey])
             let tweet = MutableTweet(text: text, media: media)
             
             let response = try await twitterClient.postTweet(tweet)
             
             tweetId = response.data.id
+            
+            text = ""
+            mediaKey = ""
           } catch {
             print(error)
           }

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -13,6 +13,7 @@ extension Twift {
     switch authenticationType {
     case .appOnly(_): return false
     case .userAccessTokens(_, _): return true
+    case .oauth2UserContext(_): return true
     }
   }
 }
@@ -43,20 +44,26 @@ struct Twift_SwiftUIApp: App {
               header: Text("User Access Tokens"),
               footer: Text("Use this authentication method for most cases.")
             ) {
-              Button {
-                Twift.Authentication().requestUserCredentials(clientCredentials: clientCredentials, callbackURL: URL(string: TWITTER_CALLBACK_URL)!) { (userCredentials, error) in
-                  if let error = error {
-                    print(error.localizedDescription)
-                  }
-                  
-                  if let creds = userCredentials {
-                    DispatchQueue.main.async {
-                      container.client = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: creds))
-                    }
-                  }
-                }
+//              Button {
+//                Twift.Authentication().requestUserCredentials(clientCredentials: clientCredentials, callbackURL: URL(string: TWITTER_CALLBACK_URL)!) { (userCredentials, error) in
+//                  if let error = error {
+//                    print(error.localizedDescription)
+//                  }
+//
+//                  if let creds = userCredentials {
+//                    DispatchQueue.main.async {
+//                      container.client = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: creds))
+//                    }
+//                  }
+//                }
+//              } label: {
+//                Text("Sign In With Twitter")
+//              }
+              
+              AsyncButton {
+                let result = await Twift.Authentication().authorizeUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ", redirectUri: URL(string: TWITTER_CALLBACK_URL)!, scope: [.offlineAccess, .usersRead, .tweetRead])
               } label: {
-                Text("Sign In With Twitter")
+                Text("Sign in")
               }
             }
             

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -13,7 +13,7 @@ extension Twift {
     switch authenticationType {
     case .appOnly(_): return false
     case .userAccessTokens(_, _): return true
-    case .oauth2UserContext(_): return true
+    case .oauth2UserAuth(_): return true
     }
   }
 }
@@ -50,7 +50,7 @@ struct Twift_SwiftUIApp: App {
                                                                            scope: Set(OAuth2Scope.allCases))
                 
                 if let user = user {
-                  container.client = Twift(.oauth2UserContext(oauth2User: user))
+                  container.client = Twift(.oauth2UserAuth(oauth2User: user))
                   
                   try? await container.client?.refreshOAuth2AccessToken()
                 }

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -46,8 +46,8 @@ struct Twift_SwiftUIApp: App {
             ) {
               AsyncButton {
                 let (user, _) = await Twift.Authentication().authenticateUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ",
-                                                                           redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
-                                                                           scope: Set(OAuth2Scope.allCases))
+                                                                              redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
+                                                                              scope: Set(OAuth2Scope.allCases))
                 
                 if let user = user {
                   container.client = Twift(.oauth2UserAuth(user))

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -44,24 +44,16 @@ struct Twift_SwiftUIApp: App {
               header: Text("User Access Tokens"),
               footer: Text("Use this authentication method for most cases.")
             ) {
-//              Button {
-//                Twift.Authentication().requestUserCredentials(clientCredentials: clientCredentials, callbackURL: URL(string: TWITTER_CALLBACK_URL)!) { (userCredentials, error) in
-//                  if let error = error {
-//                    print(error.localizedDescription)
-//                  }
-//
-//                  if let creds = userCredentials {
-//                    DispatchQueue.main.async {
-//                      container.client = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: creds))
-//                    }
-//                  }
-//                }
-//              } label: {
-//                Text("Sign In With Twitter")
-//              }
-              
               AsyncButton {
-                let result = await Twift.Authentication().authorizeUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ", redirectUri: URL(string: TWITTER_CALLBACK_URL)!, scope: [.offlineAccess, .usersRead, .tweetRead])
+                let (user, _) = await Twift.Authentication().authorizeUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ",
+                                                                           redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
+                                                                           scope: Set(OAuth2Scope.allCases))
+                
+                if let user = user {
+                  container.client = Twift(.oauth2UserContext(oauth2User: user))
+                  
+                  try? await container.client?.refreshOAuth2AccessToken()
+                }
               } label: {
                 Text("Sign in")
               }

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -41,11 +41,11 @@ struct Twift_SwiftUIApp: App {
         NavigationView {
           Form {
             Section(
-              header: Text("User Access Tokens"),
-              footer: Text("Use this authentication method for most cases.")
+              header: Text("OAuth 2.0 User Authentication"),
+              footer: Text("Use this authentication method for most cases. This test app enables all user scopes by default.")
             ) {
               AsyncButton {
-                let (user, _) = await Twift.Authentication().authorizeUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ",
+                let (user, _) = await Twift.Authentication().authenticateUser(clientId: "Sm5PSUhRNW9EZ3NXb0tJQkI5WU06MTpjaQ",
                                                                            redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
                                                                            scope: Set(OAuth2Scope.allCases))
                 
@@ -55,13 +55,13 @@ struct Twift_SwiftUIApp: App {
                   try? await container.client?.refreshOAuth2AccessToken()
                 }
               } label: {
-                Text("Sign in")
+                Text("Sign In With Twitter")
               }
             }
             
             Section(
               header: Text("App-Only Bearer Token"),
-              footer: Text("Use this authentication method for app-only methods such as filtered streams")
+              footer: Text("Use this authentication method for app-only methods such as filtered streams.")
             ) {
               TextField("Enter Bearer Token", text: $bearerToken)
               Button {

--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -50,7 +50,7 @@ struct Twift_SwiftUIApp: App {
                                                                            scope: Set(OAuth2Scope.allCases))
                 
                 if let user = user {
-                  container.client = Twift(.oauth2UserAuth(oauth2User: user))
+                  container.client = Twift(.oauth2UserAuth(user))
                   
                   try? await container.client?.refreshOAuth2AccessToken()
                 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let (oauthUser, error) = await Twift.Authentication().authenticateUser(
 )
 
 if let oauthUser = oauthUser {
-  client = Twift(.oauth2UserAuth(oauthUser: oauthUser))
+  client = Twift(.oauth2UserAuth(oauthUser))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,29 +125,3 @@ let me = response?.data
 // The user's pinned Tweet
 let tweet = response?.includes?.tweets.first
 ```
-
-### Optional Actor IDs
-
-Many of Twift's methods require a `User.ID` in order to make requests on behalf of that user. For convenience, this parameter is often marked as optional, since the currently-authenticated `User.ID` may be found on the instance's authentication type:
-
-```swift
-var client: Twift?
-var credentials: OAuthCredential?
-
-Twift.Authentication().requestUserCredentials(
-  clientCredentials: clientCredentials,
-  callbackURL: URL(string: "twift-test://")!
-) { (userCredentials, error) in
-  if let userCredentials = userCredentials {
-    client = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: userCredentials))
-    credentials = userCredentials
-  }
-}
-
-// Elsewhere in the app...
-
-// These two calls are equivalent since the client was initialized with an OAuthCredential containing the authenticated user's ID
-let result1 = try? await client?.followUser(sourceUserId: credentials.userId!, targetUserId: "12")
-let result2 = try? await client?.followUser(targetUserId: "12")
-
-```

--- a/README.md
+++ b/README.md
@@ -6,35 +6,35 @@
 Twift is an asynchronous Swift library for the Twitter v2 API.
 
 - [x] No external dependencies
-- [x] Only one callback-based method ([`Authentication.requestUserCredentials`](https://github.com/daneden/Twift/wiki/Twift_Authentication#requestusercredentialsclientcredentialscallbackurlpresentationcontextproviderwith))
+- [x] Fully async
 - [x] Full Swift type definitions/wrappers around Twitter's API objects
 
 ## Quick Start Guide
 
-New `Twift` instances must be initiated with either User Access Tokens or an App-Only Bearer Token:
+New `Twift` instances must be initiated with either OAuth 2.0 user authentication or an App-Only Bearer Token:
 
 ```swift
 // User access tokens
-let clientCredentials = OAuthCredential(key: CONSUMER_KEY, secret: CONSUMER_SECRET)
-let userCredentials = OAuthCredential(key: ACCESS_KEY, secret: ACCESS_SECRET)
-let userAuthenticatedClient = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: userCredentials)
+let oauthUser: OAuth2User = OAUTH2_USER
+let userAuthenticatedClient = Twift(.oauth2UserAuth(oauthUser: oauthUser)
 
 // Bearer token
 let appOnlyClient = Twift(.appOnly(bearerToken: BEARER_TOKEN)
 ```
 
-You can acquire user access tokens by authenticating the user with `Twift.Authentication().requestUserCredentials()`:
+You can authenticating users with `Twift.Authentication().authenticateUser()`:
 
 ```swift
 var client: Twift?
 
-Twift.Authentication().requestUserCredentials(
-  clientCredentials: clientCredentials,
-  callbackURL: URL(string: "twift-test://")!
-) { (userCredentials, error) in
-  if let creds = userCredentials {
-    client = Twift(.userAccessTokens(clientCredentials: clientCredentials, userCredentials: creds))
-  }
+let (oauthUser, error) = await Twift.Authentication().authenticateUser(
+  clientId: TWITTER_CLIENT_ID,
+  redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
+  scope: Set(OAuth2Scope.allCases)
+)
+
+if let oauthUser = oauthUser {
+  client = Twift(.oauth2UserAuth(oauthUser: oauthUser))
 }
 ```
 

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -8,8 +8,8 @@ extension Twift {
                                  body: Data? = nil,
                                  expectedReturnType: T.Type
   ) async throws -> T {
-    if case AuthenticationType.oauth2UserContext(_) = self.authenticationType {
-      try? await self.refreshOAuth2AccessToken()
+    if case AuthenticationType.oauth2UserAuth(_) = self.authenticationType {
+      try await self.refreshOAuth2AccessToken()
     }
     
     let url = getURL(for: route, queryItems: queryItems)
@@ -74,7 +74,7 @@ extension Twift {
         consumerCredentials: clientCredentials,
         userCredentials: userCredentials
       )
-    case .oauth2UserContext(let oauthUser):
+    case .oauth2UserAuth(let oauthUser):
       request.addValue("Bearer \(oauthUser.accessToken)", forHTTPHeaderField: "Authorization")
     }
     

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -70,6 +70,8 @@ extension Twift {
         consumerCredentials: clientCredentials,
         userCredentials: userCredentials
       )
+    case .oauth2UserContext(let oauthUser):
+      request.addValue("Bearer \(oauthUser.accessToken)", forHTTPHeaderField: "Authorization")
     }
   }
 }

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -8,6 +8,10 @@ extension Twift {
                                  body: Data? = nil,
                                  expectedReturnType: T.Type
   ) async throws -> T {
+    if case AuthenticationType.oauth2UserContext(_) = self.authenticationType {
+      try? await self.refreshOAuth2AccessToken()
+    }
+    
     let url = getURL(for: route, queryItems: queryItems)
     var request = URLRequest(url: url)
     

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -21,7 +21,7 @@ extension Twift {
     }
     
     signURLRequest(method: method, body: body, request: &request)
-    
+
     let (data, _) = try await URLSession.shared.data(for: request)
     
     return try decodeOrThrow(decodingType: T.self, data: data)
@@ -77,6 +77,8 @@ extension Twift {
     case .oauth2UserContext(let oauthUser):
       request.addValue("Bearer \(oauthUser.accessToken)", forHTTPHeaderField: "Authorization")
     }
+    
+    request.httpMethod = method.rawValue
   }
 }
 

--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -19,7 +19,7 @@ extension Twift {
     /// OAuth 2.0 User Context authentication.
     ///
     /// When this authentication method is used, the `oauth2User` access token may be automatically refreshed by the client if it has expired.
-    case oauth2UserAuth(oauth2User: OAuth2User)
+    case oauth2UserAuth(_ oauth2User: OAuth2User)
     
     /// App-only authentication
     case appOnly(bearerToken: String)

--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -19,7 +19,7 @@ extension Twift {
     /// OAuth 2.0 User Context authentication.
     ///
     /// When this authentication method is used, the `oauth2User` access token may be automatically refreshed by the client if it has expired.
-    case oauth2UserContext(oauth2User: OAuth2User)
+    case oauth2UserAuth(oauth2User: OAuth2User)
     
     /// App-only authentication
     case appOnly(bearerToken: String)
@@ -32,7 +32,7 @@ extension Twift {
     case userAccessTokens
     
     /// A value representing ``AuthenticationType.oauth2UserContext(_)``
-    case oauth2UserContext
+    case oauth2UserAuth
     
     /// A value representing ``AuthenticationType.appOnly(_)``
     case appOnly

--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -247,7 +247,7 @@ public struct OAuth2User: Decodable {
   public var expiresAt: Date
   
   /// The scope of permissions for this access token.
-  public var scope: [OAuth2Scope]
+  public var scope: Set<OAuth2Scope>
   
   /// Whether or not the access token has expired (i.e. whether `expiresAt` is in the past).
   public var expired: Bool {
@@ -271,7 +271,7 @@ public struct OAuth2User: Decodable {
     expiresAt = Date().addingTimeInterval(expiresIn)
     
     let scopeArray = try values.decode(String.self, forKey: .scope)
-    scope = scopeArray.split(separator: " ").compactMap { OAuth2Scope.init(rawValue: String($0)) }
+    scope = Set(scopeArray.split(separator: " ").compactMap { OAuth2Scope.init(rawValue: String($0)) })
   }
 }
 

--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -14,6 +14,12 @@ extension Twift {
     case userAccessTokens(clientCredentials: OAuthCredentials,
                           userCredentials: OAuthCredentials)
     
+    
+    /// OAuth 2.0 User Context authentication.
+    ///
+    /// When this authentication method is used, the `oauth2User` access token may be automatically refreshed by the client if it has expired.
+    case oauth2UserContext(oauth2User: OAuth2User)
+    
     /// App-only authentication
     case appOnly(bearerToken: String)
   }
@@ -22,6 +28,9 @@ extension Twift {
   public enum AuthenticationTypeRepresentation: String {
     /// A value representing ``AuthenticationType.userAccessTokens(_, _)``
     case userAccessTokens
+    
+    /// A value representing ``AuthenticationType.oauth2UserContext(_)``
+    case oauth2UserContext
     
     /// A value representing ``AuthenticationType.appOnly(_)``
     case appOnly
@@ -121,5 +130,170 @@ extension Twift {
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
       return ASPresentationAnchor()
     }
+  }
+}
+
+extension Twift.Authentication {
+  public func authorizeUser(clientId: String,
+                            redirectUri: URL,
+                            scope: Set<OAuth2Scope>,
+                            presentationContextProvider: ASWebAuthenticationPresentationContextProviding? = nil
+  ) async -> (OAuth2User?, Error?) {
+    let state = UUID().uuidString
+    
+    let authUrlQueryItems: [URLQueryItem] = [
+      URLQueryItem(name: "response_type", value: "code"),
+      URLQueryItem(name: "client_id", value: clientId),
+      URLQueryItem(name: "redirect_uri", value: redirectUri.absoluteString),
+      URLQueryItem(name: "scope", value: scope.map(\.rawValue).joined(separator: " ")),
+      URLQueryItem(name: "state", value: state),
+      URLQueryItem(name: "code_challenge", value: "challenge"),
+      URLQueryItem(name: "code_challenge_method", value: "plain"),
+    ]
+    
+    var authUrl = URLComponents()
+    authUrl.scheme = "https"
+    authUrl.host = "twitter.com"
+    authUrl.path = "/i/oauth2/authorize"
+    authUrl.queryItems = authUrlQueryItems
+    
+    let (returnedUrl, error): (URL?, Error?) = await withCheckedContinuation { continuation in
+      guard let authUrl = authUrl.url else {
+        return continuation.resume(returning: (nil, TwiftError.UnknownError(nil)))
+      }
+
+      let authSession = ASWebAuthenticationSession(url: authUrl, callbackURLScheme: redirectUri.scheme) { (url, error) in
+        return continuation.resume(returning: (url, error))
+      }
+      
+      authSession.presentationContextProvider = presentationContextProvider ?? self
+      authSession.start()
+    }
+    
+    if let error = error {
+      print(error.localizedDescription)
+      return (nil, error)
+    }
+    
+    guard let returnedUrl = returnedUrl else {
+      return (nil, TwiftError.UnknownError("No returned OAuth URL"))
+    }
+    
+    let returnedUrlComponents = URLComponents(string: returnedUrl.absoluteString)
+    
+    let returnedState = returnedUrlComponents?.queryItems?.first(where: { $0.name == "state" })?.value
+    guard let returnedState = returnedState,
+          returnedState == state else {
+      return (nil, TwiftError.UnknownError("Bad state returned from OAuth flow"))
+    }
+
+    let returnedCode = returnedUrlComponents?.queryItems?.first(where: { $0.name == "code" })?.value
+    guard let returnedCode = returnedCode else {
+      return (nil, TwiftError.UnknownError("No code returned"))
+    }
+    
+    var codeRequest = URLRequest(url: URL(string: "https://api.twitter.com/2/oauth2/token")!)
+    let body = [
+      "code": returnedCode,
+      "grant_type": "authorization_code",
+      "client_id": clientId,
+      "redirect_uri": redirectUri.absoluteString,
+      "code_verifier": "challenge"
+    ]
+    
+    let encodedBody = try? JSONSerialization.data(withJSONObject: body)
+    
+    codeRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    codeRequest.httpMethod = "POST"
+    codeRequest.httpBody = encodedBody
+    
+    do {
+      let (data, _) = try await URLSession.shared.data(for: codeRequest)
+      
+      print(String(data: data, encoding: .utf8))
+    } catch {
+      print(error.localizedDescription)
+    }
+    
+    return (nil, nil)
+  }
+}
+
+public struct OAuth2User {
+  public var clientId: String
+  public var userId: String?
+  public var accessToken: String
+  public var refreshToken: String?
+  public var expiresAt: Date
+  public var scope: [OAuth2Scope]
+  
+  public var expired: Bool {
+    expiresAt < .now
+  }
+}
+
+public enum OAuth2Scope: String, CaseIterable, RawRepresentable {
+  /// All the Tweets you can view, including Tweets from protected accounts.
+  case tweetRead = "tweet.read"
+  
+  /// Tweet and Retweet for you.
+  case tweetWrite = "tweet.write"
+  
+  /// Hide and unhide replies to your Tweets.
+  case tweetModerateWrite = "tweet.moderate.write"
+  
+  /// Any account you can view, including protected accounts.
+  case usersRead = "users.read"
+  
+  /// People who follow you and people who you follow.
+  case followsRead = "follows.read"
+  
+  /// Follow and unfollow people for you.
+  case followsWrite = "follows.write"
+  
+  /// Stay connected to your account until you revoke access.
+  case offlineAccess = "offline.access"
+  
+  /// All the Spaces you can view.
+  case spaceRead = "space.read"
+  
+  /// Accounts you’ve muted.
+  case muteRead = "mute.read"
+  
+  /// Mute and unmute accounts for you.
+  case muteWrite = "mute.write"
+  
+  /// Tweets you’ve liked and likes you can view.
+  case likeRead = "like.read"
+  
+  /// Like and un-like Tweets for you.
+  case likeWrite = "like.write"
+  
+  /// Lists, list members, and list followers of lists you’ve created or are a member of, including private lists.
+  case listRead = "list.read"
+  
+  /// Create and manage Lists for you.
+  case listWrite = "list.write"
+  
+  /// Accounts you’ve blocked.
+  case blockRead = "block.read"
+  
+  /// Block and unblock accounts for you.
+  case blockWrite = "block.write"
+  
+  /// Get Bookmarked Tweets from an authenticated user.
+  case bookmarkRead = "bookmark.read"
+  
+  /// Bookmark and remove Bookmarks from Tweets
+  case bookmarkWrite = "bookmark.write"
+  
+  /// All write-permission scopes.
+  static var allWriteScopes: Set<OAuth2Scope> {
+    [.likeWrite, .listWrite, .muteWrite, .blockWrite, .tweetWrite, .followsWrite, .bookmarkWrite, .tweetModerateWrite]
+  }
+  
+  /// All read-permission scopes.
+  static var allReadScopes: Set<OAuth2Scope> {
+    [.likeRead, .listRead, .muteRead, .blockRead, .spaceRead, .tweetRead, .usersRead, .followsRead, .bookmarkRead]
   }
 }

--- a/Sources/Twift+Media.swift
+++ b/Sources/Twift+Media.swift
@@ -22,6 +22,7 @@ extension Twift {
   ///   - progress: An optional pointer to a `Progress` instance, used to track the progress of the upload task.
   ///   The progress is based on the number of base64 chunks the data is split into; each chunk will be approximately 2mb in size.
   /// - Returns: A ``MediaUploadResponse`` object containing information about the uploaded media, including its `mediaIdString`, which is used to attach media to Tweets
+  @available(*, deprecated, message: "Media methods currently depend on OAuth 1.0a authentication, which will be deprecated in a future version of Twift. These media methods may be removed or replaced in the future.")
   public func upload(mediaData: Data, mimeType: String, category: MediaCategory, progress: UnsafeMutablePointer<Progress>? = nil) async throws -> MediaUploadResponse {
     let initializeResponse = try await initializeUpload(data: mediaData, mimeType: mimeType)
     try await appendMediaChunks(mediaKey: initializeResponse.mediaIdString, data: mediaData, progress: progress)
@@ -38,6 +39,7 @@ extension Twift {
   /// - Parameters:
   ///   - mediaId: The target media to attach alt text to
   ///   - text: The alt text to attach to the `mediaId`
+  @available(*, deprecated, message: "Media methods currently depend on OAuth 1.0a authentication, which will be deprecated in a future version of Twift. These media methods may be removed or replaced in the future.")
   public func addAltText(to mediaId: Media.ID, text: String) async throws {
     guard case .userAccessTokens(let clientCredentials, let userCredentials) = self.authenticationType else {
       throw TwiftError.WrongAuthenticationType(needs: .userAccessTokens)
@@ -72,6 +74,7 @@ extension Twift {
   /// Checks to see whether the `mediaId` has finished processing successfully. This method will wait for the `GET /1.1/media/upload.json?command=STATUS` endpoint to return either `succeeded` or `failed`; for large videos, this may take some time.
   /// - Parameter mediaId: The media ID to check the upload status of
   /// - Returns: A `Bool` indicating whether the media has uploaded successfully (`true`) or not (`false`).
+  @available(*, deprecated, message: "Media methods currently depend on OAuth 1.0a authentication, which will be deprecated in a future version of Twift. These media methods may be removed or replaced in the future.")
   public func checkMediaUploadSuccessful(_ mediaId: Media.ID) async throws -> Bool {
     var urlComponents = baseMediaURLComponents()
     urlComponents.queryItems = [
@@ -113,6 +116,7 @@ extension Twift {
 
 extension Twift {
   // MARK: Media Helper Methods
+  @available(*, deprecated, message: "Media methods currently depend on OAuth 1.0a authentication, which will be deprecated in a future version of Twift. These media methods may be removed or replaced in the future.")
   fileprivate func initializeUpload(data: Data, mimeType: String) async throws -> MediaInitResponse {
     guard case .userAccessTokens(let clientCredentials, let userCredentials) = self.authenticationType else {
       throw TwiftError.WrongAuthenticationType(needs: .userAccessTokens)

--- a/Sources/Twift+Media.swift
+++ b/Sources/Twift+Media.swift
@@ -14,6 +14,7 @@ public enum MediaCategory: String {
 extension Twift {
   // MARK: Chunked Media Upload
   /// Uploads media data and returns an ID string that can be used to attach media to Tweets
+  /// - Warning: This method relies on Twitter's v1.1 media API endpoints and only supports OAuth 1.0a authentication.
   /// - Parameters:
   ///   - mediaData: The media data to upload
   ///   - mimeType: The type of media you're uploading
@@ -33,6 +34,7 @@ extension Twift {
   /// 1. Upload media using the `upload(mediaData)` method
   /// 2. Add alt text to the `mediaId` returned from step 1 via this method
   /// 3. Create a Tweet with the `mediaId`
+  /// - Warning: This method relies on Twitter's v1.1 media API endpoints and only supports OAuth 1.0a authentication.
   /// - Parameters:
   ///   - mediaId: The target media to attach alt text to
   ///   - text: The alt text to attach to the `mediaId`

--- a/Sources/Twift+Tweets.swift
+++ b/Sources/Twift+Tweets.swift
@@ -227,7 +227,7 @@ public struct MutableTweet: Codable {
 /// A mutable Media object for posting media with `MutableTweet`
 public struct MutableMedia: Codable {
   /// A list of Media IDs being attached to the Tweet.
-  public var mediaIds: [Media.ID]
+  public var mediaIds: [Media.ID]?
   
   /// A list of User IDs being tagged in the Tweet with Media. If the user you're tagging doesn't have photo-tagging enabled, their names won't show up in the list of tagged users even though the Tweet is successfully created.
   public var taggedUserIds: [User.ID]?

--- a/Sources/Twift.swift
+++ b/Sources/Twift.swift
@@ -25,7 +25,7 @@ public class Twift: NSObject, ObservableObject {
       return userCredentials.userId
     case .appOnly(_):
       return nil
-    case .oauth2UserContext(_):
+    case .oauth2UserAuth(_):
       return nil
     }
   }
@@ -70,10 +70,10 @@ public class Twift: NSObject, ObservableObject {
   /// Refreshes the OAuth 2.0 token, optionally forcing a refresh even if the token is still valid
   /// - Parameter onlyIfExpired: Set to false to force the token to refresh even if it hasn't yet expired.
   public func refreshOAuth2AccessToken(onlyIfExpired: Bool = true) async throws {
-    guard case AuthenticationType.oauth2UserContext(let oauthUser) = self.authenticationType,
+    guard case AuthenticationType.oauth2UserAuth(let oauthUser) = self.authenticationType,
           let refreshToken = oauthUser.refreshToken,
           let clientId = oauthUser.clientId else {
-      throw TwiftError.WrongAuthenticationType(needs: .oauth2UserContext)
+      throw TwiftError.WrongAuthenticationType(needs: .oauth2UserAuth)
     }
     
     // Return early if the token has not yet expired
@@ -100,6 +100,6 @@ public class Twift: NSObject, ObservableObject {
     var refreshedOAuthUser = try JSONDecoder().decode(OAuth2User.self, from: data)
     refreshedOAuthUser.clientId = clientId
     
-    self.authenticationType = .oauth2UserContext(oauth2User: refreshedOAuthUser)
+    self.authenticationType = .oauth2UserAuth(oauth2User: refreshedOAuthUser)
   }
 }

--- a/Sources/Twift.swift
+++ b/Sources/Twift.swift
@@ -25,6 +25,8 @@ public class Twift: NSObject, ObservableObject {
       return userCredentials.userId
     case .appOnly(_):
       return nil
+    case .oauth2UserContext(let user):
+      return user.userId
     }
   }
   

--- a/Sources/Twift.swift
+++ b/Sources/Twift.swift
@@ -100,6 +100,6 @@ public class Twift: NSObject, ObservableObject {
     var refreshedOAuthUser = try JSONDecoder().decode(OAuth2User.self, from: data)
     refreshedOAuthUser.clientId = clientId
     
-    self.authenticationType = .oauth2UserAuth(oauth2User: refreshedOAuthUser)
+    self.authenticationType = .oauth2UserAuth(refreshedOAuthUser)
   }
 }

--- a/Sources/Types+Place.swift
+++ b/Sources/Types+Place.swift
@@ -37,7 +37,7 @@ public struct GeoJSON: Codable {
 /// An object containing details for a location
 public struct Geo: Codable {
   /// The location's coordinates
-  public let coordinates: Coordinates
+  public let coordinates: Coordinates?
   
   /// The location's unique ID
   public let placeId: String


### PR DESCRIPTION
Fixes #11. This PR adds OAuth 2.0 user authentication, including automatic token refreshing and deprecation of OAuth 1.0a authentication methods.

To do:
- [x] ~Fix~ Deprecate methods that rely on OAuth 1.0a (media methods). Unfortunately media methods don't support OAuth 2.0 authentication. When Twitter eventually adds V2 media endpoints, they might have a different API which means that both Twift's current media methods and new ones might coexist; I'll plan to mark the current method as deprecated in advance of this change.
- [x] Test that OAuth 2.0 works as expected on all methods
- [ ] ~Add scope checks for methods. Most (all?) OAuth 2.0 endpoints have specific scopes that can use them. To save network trips, it might be nice to throw errors when an attempt is made to call a method with the wrong scope.~ Decided against this as it would just end up adding layers of misdirection between the library and Twitter's API; Twitter's errors should be enough to communicate insufficient scope errors.