### PR TITLE
Expand getListTweets to accept user fields

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -42,6 +42,14 @@ extension Twift {
     
     return queryItems
   }
+    
+    internal func fieldsOnly<T: Fielded>(for type: T.Type, fields: Set<T.Field>) -> [URLQueryItem] {
+        var queryItems: [URLQueryItem] = []
+        
+        if !fields.isEmpty { queryItems.append(URLQueryItem(name: T.fieldParameterName, value: fields.compactMap { T.fieldName(field: $0) }.joined(separator: ","))) }
+        
+        return queryItems
+    }
 }
 
 extension Twift {

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -15,6 +15,7 @@ extension Twift {
   /// - Returns: A response object containing an array of Tweets, included expansions, and meta data for pagination
   public func getListTweets(_ listId: List.ID,
                             fields: Set<Tweet.Field> = [],
+                            userFields: Set<User.Field> = [],
                             expansions: [Tweet.Expansions] = [],
                             paginationToken: String? = nil,
                             maxResults: Int = 100
@@ -26,6 +27,7 @@ extension Twift {
     }
     
     queryItems += fieldsAndExpansions(for: Tweet.self, fields: fields, expansions: expansions)
+    queryItems += fieldsOnly(for: User.self, fields: userFields)
     
     return try await call(route: .listTweets(listId),
                           queryItems: queryItems,


### PR DESCRIPTION
Thought to add another method that expands this specific call to accept userFields as well.
It is basically a copy of `fieldsAndExpansions` but without the expansions field included.

This is in connection to this issue: https://github.com/daneden/Twift/issues/19#issue-1192211435

Users can request all tweets from a list but it lacks profilePhotos of the users that posted in the said list. 

After this PR we might expand to accept all types of fileds, as it is noted as possible in the API.