### PR TITLE
make mediaKeys and pollIds accessible to the user

### DIFF
--- a/Sources/Types+Tweet.swift
+++ b/Sources/Types+Tweet.swift
@@ -77,8 +77,8 @@ extension Tweet {
   }
   
   public struct Attachments: Codable {
-    let pollIds: [String]?
-    let mediaKeys: [String]?
+    public let pollIds: [String]?
+    public let mediaKeys: [String]?
   }
   
   public struct Entities: Codable {


### PR DESCRIPTION
The only way to gain access to the image urls posted in the tweet is to access the `mediaKeys` which are then fetched from the `includes` model.