### PR TITLE
Rename property to use snake_case

### DIFF
--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -49,7 +49,7 @@ public struct Media: Codable, Identifiable {
 
 public enum MediaType: String, Codable, RawRepresentable {
   /// Animated .gif media type
-  case animatedGif
+  case animatedGif = "animated_gif"
   
   /// Video media type
   case video


### PR DESCRIPTION
This might be the actual culprit for the issue I posted: https://github.com/daneden/Twift/issues/25

I only noticed it after seeing that I do get preview URLs for images without issues, but when there is a gif, the response fails

```swift
{\"media_key\":\"16_1527660993324752897\",\"type\":\"animated_gif\"},
```

🤞