### PR TITLE
Make authenticateUser function throwing

### DIFF
--- a/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
+++ b/Demo App/Twift_SwiftUI/Twift_SwiftUIApp.swift
@@ -45,7 +45,7 @@ struct Twift_SwiftUIApp: App {
               footer: Text("Use this authentication method for most cases. This test app enables all user scopes by default.")
             ) {
               AsyncButton {
-                let (user, _) = await Twift.Authentication().authenticateUser(clientId: CLIENT_ID,
+                let user = try? await Twift.Authentication().authenticateUser(clientId: CLIENT_ID,
                                                                               redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
                                                                               scope: Set(OAuth2Scope.allCases))
                 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,21 @@ You can authenticate users with `Twift.Authentication().authenticateUser()`:
 ```swift
 var client: Twift?
 
-let (oauthUser, error) = await Twift.Authentication().authenticateUser(
-  clientId: TWITTER_CLIENT_ID,
-  redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
-  scope: Set(OAuth2Scope.allCases)
-)
-
-if let oauthUser = oauthUser {
+do {
+  let oauthUser = try await Twift.Authentication().authenticateUser(
+    clientId: TWITTER_CLIENT_ID,
+    redirectUri: URL(string: TWITTER_CALLBACK_URL)!,
+    scope: Set(OAuth2Scope.allCases)
+  )
+  
   client = Twift(.oauth2UserAuth(oauthUser))
   
   // It's recommended that you store your user auth tokens via Keychain or another secure storage method.
   // OAuth2User can be encoded to a data object for storage and later retrieval.
   let encoded = try? JSONEncoder().encode(oauthUser))
   saveUserAuthExample(encoded) // Saves the data to Keychain, for example
+} catch {
+  print(error.localizedDescription)
 }
 ```
 

--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -165,7 +165,7 @@ extension Twift.Authentication {
   ///   - redirectUri: The URI to redirect users to after completing authentication.
   ///   - scope: The user access scopes for your authentication. For automatic token refreshing, ensure that `offlineAccess` is included in the scope.
   ///   - presentationContextProvider: Optional presentation context provider. When not provided, this function will handle the presentation context itself.
-  /// - Returns: A tuple containing the authenticated user access tokens or any encoutered error.
+  /// - Returns: The authenticated user access tokens.
   public func authenticateUser(clientId: String,
                                redirectUri: URL,
                                scope: Set<OAuth2Scope>,


### PR DESCRIPTION
This pull request adds a throwing version of `authenticateUser` function.

By making this function throwing we remove from the user the need to handle third (most likely never happening) state where both user and error are nil.