### PR TITLE
Make entities pertaining to urls, hashtags and mentions public

### DIFF
--- a/Sources/Types+Tweet.swift
+++ b/Sources/Types+Tweet.swift
@@ -84,9 +84,9 @@ extension Tweet {
   public struct Entities: Codable {
     let annotations: [AnnotationEntity]?
     let cashtags: [TagEntity]?
-    let hashtags: [TagEntity]?
-    let mentions: [MentionEntity]?
-    let urls: [URLEntity]?
+    public let hashtags: [TagEntity]?
+    public let mentions: [MentionEntity]?
+    public let urls: [URLEntity]?
   }
   
   public struct AnnotationEntity: EntityObject {
@@ -101,8 +101,8 @@ extension Tweet {
     let start: Int
     let end: Int
     let url: URL
-    let expandedUrl: URL
-    let displayUrl: String
+    public let expandedUrl: URL
+    public let displayUrl: String
     let title: String?
     let description: String?
   }

--- a/Sources/Types+Tweet.swift
+++ b/Sources/Types+Tweet.swift
@@ -82,8 +82,8 @@ extension Tweet {
   }
   
   public struct Entities: Codable {
-    let annotations: [AnnotationEntity]?
-    let cashtags: [TagEntity]?
+    public let annotations: [AnnotationEntity]?
+    public let cashtags: [TagEntity]?
     public let hashtags: [TagEntity]?
     public let mentions: [MentionEntity]?
     public let urls: [URLEntity]?
@@ -98,13 +98,13 @@ extension Tweet {
   }
   
   public struct URLEntity: EntityObject {
-    let start: Int
-    let end: Int
-    let url: URL
+    public let start: Int
+    public let end: Int
+    public let url: URL
     public let expandedUrl: URL
     public let displayUrl: String
-    let title: String?
-    let description: String?
+    public let title: String?
+    public let description: String?
   }
   
   /// Tweet engagement metrics only visible to the Tweet author/promoter


### PR DESCRIPTION
@daneden 
The majority of developers would probably like to have access to hashtags and mentions for syntax highlighting purposes.

Also, in cases of Video links or gifs, we would need to access the expanded URL to make it easier for rendering within the app.

I did not make all the properties public but in the future, we might as well?