### PR TITLE
Fix token expiry date

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -46,6 +46,14 @@ extension Twift {
     
     return queryItems
   }
+    
+    internal func fieldsOnly<T: Fielded>(for type: T.Type, fields: Set<T.Field>) -> [URLQueryItem] {
+        var queryItems: [URLQueryItem] = []
+        
+        if !fields.isEmpty { queryItems.append(URLQueryItem(name: T.fieldParameterName, value: fields.compactMap { T.fieldName(field: $0) }.joined(separator: ","))) }
+        
+        return queryItems
+    }
 }
 
 extension Twift {

--- a/Sources/Twift+Lists.swift
+++ b/Sources/Twift+Lists.swift
@@ -15,6 +15,7 @@ extension Twift {
   /// - Returns: A response object containing an array of Tweets, included expansions, and meta data for pagination
   public func getListTweets(_ listId: List.ID,
                             fields: Set<Tweet.Field> = [],
+                            userFields: Set<User.Field> = [],
                             expansions: [Tweet.Expansions] = [],
                             paginationToken: String? = nil,
                             maxResults: Int = 100
@@ -26,6 +27,7 @@ extension Twift {
     }
     
     queryItems += fieldsAndExpansions(for: Tweet.self, fields: fields, expansions: expansions)
+    queryItems += fieldsOnly(for: User.self, fields: userFields)
     
     return try await call(route: .listTweets(listId),
                           queryItems: queryItems,

--- a/Sources/Twift.swift
+++ b/Sources/Twift.swift
@@ -5,14 +5,7 @@ import Combine
 public class Twift: NSObject, ObservableObject {
   /// The type of authentication access for this Twift instance
   public private(set) var authenticationType: AuthenticationType
-  public var oauthUser: OAuth2User? {
-    switch authenticationType {
-      case .oauth2UserAuth(let user, _):
-        return user
-      default:
-        return nil
-    }
-  }
+  public private(set) var oauthUser: OAuth2User?
   
   internal let decoder: JSONDecoder
   internal let encoder: JSONEncoder
@@ -23,22 +16,6 @@ public class Twift: NSObject, ObservableObject {
     
     self.decoder = Self.initializeDecoder()
     self.encoder = Self.initializeEncoder()
-  }
-  
-  /// Initialises an instance with OAuth2 User authentication
-  /// - Parameters:
-  ///   - oauth2User: The OAuth2 User object for authenticating requests on behalf of a user
-  ///   - onTokenRefresh: A callback invoked when the access token is refreshed by Twift. Useful for storing updated credentials.
-  public convenience init(oauth2User: OAuth2User,
-                          onTokenRefresh: @escaping (OAuth2User) -> Void = { _ in }) {
-    self.init(.oauth2UserAuth(oauth2User, onRefresh: onTokenRefresh))
-  }
-  
-  /// Initialises an instance with App-Only Bearer Token authentication
-  /// - Parameters:
-  ///   - appOnlyBearerToken: The App-Only Bearer Token issued by Twitter for authenticating requests
-  public convenience init(appOnlyBearerToken: String) {
-    self.init(.appOnly(bearerToken: appOnlyBearerToken))
   }
   
   /// Swift's native implementation of ISO 8601 date decoding defaults to a format that doesn't include milliseconds, causing decoding errors because of Twitter's date format.
@@ -95,10 +72,9 @@ public class Twift: NSObject, ObservableObject {
   }
   
   /// Refreshes the OAuth 2.0 token, optionally forcing a refresh even if the token is still valid
-  /// After a successful refresh, a user-defined callback is performed. (optional)
   /// - Parameter onlyIfExpired: Set to false to force the token to refresh even if it hasn't yet expired.
   public func refreshOAuth2AccessToken(onlyIfExpired: Bool = true) async throws {
-    guard case AuthenticationType.oauth2UserAuth(let oauthUser, let refreshCompletion) = self.authenticationType else {
+    guard case AuthenticationType.oauth2UserAuth(let oauthUser) = self.authenticationType else {
       throw TwiftError.WrongAuthenticationType(needs: .oauth2UserAuth)
     }
     
@@ -130,12 +106,8 @@ public class Twift: NSObject, ObservableObject {
     
     var refreshedOAuthUser = try JSONDecoder().decode(OAuth2User.self, from: data)
     refreshedOAuthUser.clientId = clientId
-    refreshedOAuthUser.expiresAt = Date().addingTimeInterval(oauthUser.expiresIn)
     
-    if let refreshCompletion = refreshCompletion {
-      refreshCompletion(refreshedOAuthUser)
-    }
-    
-    self.authenticationType = .oauth2UserAuth(refreshedOAuthUser, onRefresh: refreshCompletion)
+	self.authenticationType = .oauth2UserAuth(refreshedOAuthUser)
+	self.oauthUser = refreshedOAuthUser
   }
 }

--- a/Sources/Twift.swift
+++ b/Sources/Twift.swift
@@ -130,6 +130,7 @@ public class Twift: NSObject, ObservableObject {
     
     var refreshedOAuthUser = try JSONDecoder().decode(OAuth2User.self, from: data)
     refreshedOAuthUser.clientId = clientId
+    refreshedOAuthUser.expiresAt = Date().addingTimeInterval(oauthUser.expiresIn)
     
     if let refreshCompletion = refreshCompletion {
       refreshCompletion(refreshedOAuthUser)


### PR DESCRIPTION
As detailed in this issue, token was getting new date on every encode/decode, therefore never expiring.

This PR omits setting the `expiresAt` date and tries to only set it during first authentication and refresh.

After this, we might want to explore the option of a force refresh if 401 response is received.
That way expiry would never really need to be logged as we can always try with the old token and refresh if the bad response is received.
