### PR TITLE
Update Twift+Streams.swift

### DIFF
--- a/Sources/Twift+Streams.swift
+++ b/Sources/Twift+Streams.swift
@@ -39,7 +39,7 @@ extension Twift {
     
     return bytes.lines
       .compactMap {
-        try? self.decodeOrThrow(decodingType: TwitterAPIDataAndIncludes.self, data: Data($0.utf8))
+        try? await self.decodeOrThrow(decodingType: TwitterAPIDataAndIncludes.self, data: Data($0.utf8))
       }
   }
   
@@ -79,7 +79,7 @@ extension Twift {
     
     return bytes.lines
       .compactMap {
-        try? self.decodeOrThrow(decodingType: TwitterAPIDataAndIncludes.self, data: Data($0.utf8))
+        try? await self.decodeOrThrow(decodingType: TwitterAPIDataAndIncludes.self, data: Data($0.utf8))
       }
   }
 }


### PR DESCRIPTION
Fix "Expression is 'async' but is not marked with 'await'" error by adding await keyword at return of 'volumeStream' and 'filteredStream' functions