### PR TITLE
Extend media Type with variants property

### DIFF
--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -45,6 +45,9 @@ public struct Media: Codable, Identifiable {
   
   /// URL to the media content
   public let url: URL?
+  
+  /// Each media object may have multiple display or playback variants, with different resolutions or formats
+  public let variants: [Variant]?
 }
 
 public enum MediaType: String, Codable, RawRepresentable {
@@ -86,6 +89,17 @@ extension Media {
     /// The number of views the media has received
     public let viewCount: Int
   }
+  
+  public struct Variant: Codable {
+    /// Bitrate of the media resource
+    var bitRate: Int?
+    
+    /// Type of media
+    var contentType: MediaType
+    
+    /// URL to the media content
+    var url: String
+  }
 }
 
 extension Media: Fielded {
@@ -104,6 +118,7 @@ extension Media: Fielded {
     case \.url: return "url"
     case \.organicMetrics: return "organic_metrics"
     case \.promotedMetrics: return "promoted_metrics"
+    case \.variants: return "variants"
     default: return nil
     }
   }


### PR DESCRIPTION
To be able to fetch the videos direct URL, we need the `variants` field and a `Variant` model.

Right now, you can only get a twitter URL of the media, but not of the video resource as well. Crucial part to be able to play the video in your app.

More details on this link
https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/media

That page is not fully up to date tho.
I joined a Twitter Chirp slack where I asked about fetching video/gif URL and got info that this is now possible (on the link it still says "Note that video URLs are not currently available, only static images.") 😅

Tested this in a playground here:
[playground](https://oauth-playground.glitch.me/?id=listsIdTweets&params=%28%27id%21%271513494613096599558%27%7Eexpansion2-.media_keys%27%7Emax_result24%27%7Euser*%27%7Etweet*-%2Centities%27%7Emedia*url%2Cvariants%27%29*.field2-attachments2s%21%27%012-*_)

@daneden , I hope this makes sense 🙌