### PR TITLE
Add contentMediaType for variants object

### DIFF
--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -66,6 +66,15 @@ public enum MediaType: String, Codable, RawRepresentable {
   #endif
 }
 
+/// Media type specific to `variants` object
+public enum ContentMediaType: String, Codable, RawRepresentable {
+  /// Mpeg media type
+  case mpeg = "application/x-mpegURL"
+  
+  /// MP4 video media type. Gif media falls into this case too.
+  case video = "video/mp4"
+}
+
 extension Media {
   public struct Metrics: Codable {
     /// The number of viewers who watched beyond 0% of the video duration

--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 /// Media refers to any image, GIF, or video attached to a Tweet. The media object is not a primary object on any endpoint, but can be found and expanded in the Tweet object. 
 public struct Media: Codable, Identifiable {
@@ -66,15 +67,6 @@ public enum MediaType: String, Codable, RawRepresentable {
   #endif
 }
 
-/// Media type specific to `variants` object
-public enum ContentMediaType: String, Codable, RawRepresentable {
-  /// Mpeg media type
-  case mpeg = "application/x-mpegURL"
-  
-  /// MP4 video media type. Gif media falls into this case too.
-  case video = "video/mp4"
-}
-
 extension Media {
   public struct Metrics: Codable {
     /// The number of viewers who watched beyond 0% of the video duration
@@ -104,7 +96,7 @@ extension Media {
     public var bitRate: Int?
     
     /// Type of media
-    public var contentType: ContentMediaType
+    public var contentType: UTType
     
     /// URL to the media content
     public var url: String

--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UniformTypeIdentifiers
 
 /// Media refers to any image, GIF, or video attached to a Tweet. The media object is not a primary object on any endpoint, but can be found and expanded in the Tweet object. 
 public struct Media: Codable, Identifiable {
@@ -96,7 +95,7 @@ extension Media {
     public var bitRate: Int?
     
     /// Type of media
-    public var contentType: UTType
+    public var contentType: String
     
     /// URL to the media content
     public var url: String

--- a/Sources/Types+Media.swift
+++ b/Sources/Types+Media.swift
@@ -104,7 +104,7 @@ extension Media {
     public var bitRate: Int?
     
     /// Type of media
-    public var contentType: MediaType
+    public var contentType: ContentMediaType
     
     /// URL to the media content
     public var url: String


### PR DESCRIPTION
Unfortunately I was not able to find proper spec in the Twitter API for this before, and only way to really test this is to have it in the package and use it.

Or could we somehow test this in the demo app @daneden ?

As for this PR, I presumed that mediaType and contentType are the same, however from a bit of testing it turns you types slightly differ in strings, so we needed a new enum to handle that.