### PR TITLE
Make properties of annotation public

### DIFF
--- a/Sources/Types+Tweet.swift
+++ b/Sources/Types+Tweet.swift
@@ -90,11 +90,11 @@ extension Tweet {
   }
   
   public struct AnnotationEntity: EntityObject {
-    let start: Int
-    let end: Int
-    let probability: Double
-    let type: String
-    let normalizedText: String
+    public let start: Int
+    public let end: Int
+    public let probability: Double
+    public let type: String
+    public let normalizedText: String
   }
   
   public struct URLEntity: EntityObject {


### PR DESCRIPTION
Quite similar as with URLEntity and base Entities, we need access to `Annotation` properties to be able to use them for highlighting or any data handling.