### PR TITLE
Fix decoding error for searchRecentTweets if there is no data

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -343,7 +343,7 @@ public struct TwitterAPIDataAndIncludes<Resource: Codable, Includes: Codable>: C
 /// A response object from the Twitter API containing the requested object(s) in the `data` property,  expansions in the `includes` property, and additional information (such as pagination tokens) in the `meta` property
 public struct TwitterAPIDataIncludesAndMeta<Resource: Codable, Includes: Codable, Meta: Codable>: Codable {
   /// The requested object(s)
-  public let data: Resource
+  public let data: Resource?
   
   /// Any requested expansions
   public let includes: Includes?

--- a/Tests/TwiftTests/TwiftTests+Blocks.swift
+++ b/Tests/TwiftTests/TwiftTests+Blocks.swift
@@ -22,6 +22,6 @@ final class TwiftBlockTests: XCTestCase {
   
   func testGetBlockedUsers() async throws {
     let getBlockedUsersResult = try await TwiftTests.userAuthClient.getBlockedUsers(for: "0")
-    XCTAssertEqual(getBlockedUsersResult.data.count, 1)
+    XCTAssertEqual(getBlockedUsersResult.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Bookmarks.swift
+++ b/Tests/TwiftTests/TwiftTests+Bookmarks.swift
@@ -21,6 +21,6 @@ final class TwiftBookmarkTests: XCTestCase {
   
   func testGetBookmarks() async throws {
     let getBookmarksTest = try await TwiftTests.userAuthClient.getBookmarks(for: "0")
-    XCTAssertEqual(getBookmarksTest.data.count, 1)
+    XCTAssertEqual(getBookmarksTest.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Follows.swift
+++ b/Tests/TwiftTests/TwiftTests+Follows.swift
@@ -21,11 +21,11 @@ final class TwiftFollowTests: XCTestCase {
   
   func testGetFollowing() async throws {
     let getFollowingResult = try await TwiftTests.userAuthClient.getFollowing("0")
-    XCTAssertEqual(getFollowingResult.data.count, 1)
+    XCTAssertEqual(getFollowingResult.data?.count, 1)
   }
   
   func testGetFollowers() async throws {
     let getFollowersResult = try await TwiftTests.userAuthClient.getFollowers("0")
-    XCTAssertEqual(getFollowersResult.data.count, 1)
+    XCTAssertEqual(getFollowersResult.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Likes.swift
+++ b/Tests/TwiftTests/TwiftTests+Likes.swift
@@ -21,11 +21,11 @@ final class TwiftLikeTests: XCTestCase {
   
   func testGetLikedTweets() async throws {
     let getLikedTweetsResult = try await TwiftTests.userAuthClient.getLikedTweets(for: "0")
-    XCTAssertEqual(getLikedTweetsResult.data.count, 1)
+    XCTAssertEqual(getLikedTweetsResult.data?.count, 1)
   }
   
   func testGetLikingUsers() async throws {
     let getLikingUsers = try await TwiftTests.userAuthClient.getLikingUsers(for: "0")
-    XCTAssertEqual(getLikingUsers.data.count, 1)
+    XCTAssertEqual(getLikingUsers.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Lists.swift
+++ b/Tests/TwiftTests/TwiftTests+Lists.swift
@@ -11,7 +11,7 @@ import XCTest
 final class TwiftListTests: XCTestCase {
   func testGetListTweets() async throws {
     let getListTweetsResult = try await TwiftTests.userAuthClient.getListTweets("0")
-    XCTAssertEqual(getListTweetsResult.data.count, 1)
+    XCTAssertEqual(getListTweetsResult.data?.count, 1)
   }
   
   func testGetList() async throws {
@@ -26,17 +26,17 @@ final class TwiftListTests: XCTestCase {
    
   func testGetListMembers() async throws {
     let getListMembersResult = try await TwiftTests.userAuthClient.getListMembers(for: "0")
-    XCTAssertEqual(getListMembersResult.data.count, 1)
+    XCTAssertEqual(getListMembersResult.data?.count, 1)
   }
   
   func testGetListMemberships() async throws {
     let getListMembershipsResult = try await TwiftTests.userAuthClient.getListMemberships(for: "0")
-    XCTAssertEqual(getListMembershipsResult.data.count, 1)
+    XCTAssertEqual(getListMembershipsResult.data?.count, 1)
   }
   
   func testGetUserOwnedLists() async throws {
     let getUserOwnedListsResult = try await TwiftTests.userAuthClient.getUserOwnedLists("0")
-    XCTAssertEqual(getUserOwnedListsResult.data.count, 1)
+    XCTAssertEqual(getUserOwnedListsResult.data?.count, 1)
   }
   
   func testCreateList() async throws {
@@ -71,12 +71,12 @@ final class TwiftListTests: XCTestCase {
   
   func testGetListFollowers() async throws {
     let getListFollowersResult = try await TwiftTests.userAuthClient.getListFollowers("0")
-    XCTAssertEqual(getListFollowersResult.data.count, 1)
+    XCTAssertEqual(getListFollowersResult.data?.count, 1)
   }
   
   func testGetFollowedLists() async throws {
     let getFollowedListsResult = try await TwiftTests.userAuthClient.getFollowedLists("0")
-    XCTAssertEqual(getFollowedListsResult.data.count, 1)
+    XCTAssertEqual(getFollowedListsResult.data?.count, 1)
   }
   
   func testPinList() async throws {

--- a/Tests/TwiftTests/TwiftTests+Mutes.swift
+++ b/Tests/TwiftTests/TwiftTests+Mutes.swift
@@ -21,6 +21,6 @@ final class TwiftMuteTests: XCTestCase {
   
   func testGetMutedUsers() async throws {
     let getMutedUsersResult = try await TwiftTests.userAuthClient.getMutedUsers(for: "0")
-    XCTAssertEqual(getMutedUsersResult.data.count, 1)
+    XCTAssertEqual(getMutedUsersResult.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Retweets.swift
+++ b/Tests/TwiftTests/TwiftTests+Retweets.swift
@@ -26,6 +26,6 @@ final class TwiftRetweetTests: XCTestCase {
   
   func testQuoteTweets() async throws {
     let quoteTweetsResult = try await TwiftTests.userAuthClient.quoteTweets(for: "0")
-    XCTAssertEqual(quoteTweetsResult.data.count, 1)
+    XCTAssertEqual(quoteTweetsResult.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Search.swift
+++ b/Tests/TwiftTests/TwiftTests+Search.swift
@@ -11,11 +11,11 @@ import XCTest
 final class TwiftSearchTests: XCTestCase {
   func testSearchAllTweets() async throws {
     let searchAllTweetsResult = try await TwiftTests.userAuthClient.searchAllTweets(query: "test")
-    XCTAssertEqual(searchAllTweetsResult.data.count, 1)
+    XCTAssertEqual(searchAllTweetsResult.data?.count, 1)
   }
   
   func testSearchRecentTweets() async throws {
     let searchRecentTweetsResult = try await TwiftTests.userAuthClient.searchRecentTweets(query: "test")
-    XCTAssertEqual(searchRecentTweetsResult.data.count, 1)
+    XCTAssertEqual(searchRecentTweetsResult.data?.count, 1)
   }
 }

--- a/Tests/TwiftTests/TwiftTests+Tweets.swift
+++ b/Tests/TwiftTests/TwiftTests+Tweets.swift
@@ -12,17 +12,17 @@ import XCTest
 final class TwiftTweetTests: XCTestCase {
   func testUserTimeline() async throws {
     let userTimelineResult = try await TwiftTests.userAuthClient.userTimeline("0")
-    XCTAssertEqual(userTimelineResult.data.count, 1)
+    XCTAssertEqual(userTimelineResult.data?.count, 1)
   }
   
   func testUserMentions() async throws {
     let userMentionsResult = try await TwiftTests.userAuthClient.userMentions("0")
-    XCTAssertEqual(userMentionsResult.data.count, 1)
+    XCTAssertEqual(userMentionsResult.data?.count, 1)
   }
   
   func testReverseChronologicalTimeline() async throws {
     let userMentionsResult = try await TwiftTests.userAuthClient.reverseChronologicalTimeline("0")
-    XCTAssertEqual(userMentionsResult.data.count, 1)
+    XCTAssertEqual(userMentionsResult.data?.count, 1)
   }
   
   func testGetTweet() async throws {


### PR DESCRIPTION
When calling `searchRecentTweets` method the response from Twitter might not contain `data` property which results in decoding error for `TwitterAPIDataIncludesAndMeta`.

Example response:
```json
{
  "meta": {
    "result_count": 0
  }
}
```

This pull request makes `data` property optional which resolves decoding issue. But perhaps a better idea would be to introduce a separate type for cases where data is an Array and instead of optional return empty? Or even change `Resource` type of `TwitterAPIDataIncludesAndMeta` to always expect array? Looking at the tests there are no cases where data is of non-array type.