### PR TITLE
Percent encode ( and ) characters in query parameters

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -68,7 +68,10 @@ extension Twift {
     }
     
     components.queryItems = combinedQueryItems
-    components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: ":", with: "%3A")
+
+    var allowedCharacters = CharacterSet.urlQueryAllowed
+    allowedCharacters.remove(charactersIn: ":()")
+    components.percentEncodedQuery = components.query?.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
     
     return components.url!
   }


### PR DESCRIPTION
Encountered another pair of problematic characters used in query for search API call. This time it is `(` and `)`.