### PR TITLE
Ensure AuthenticationServices methods are called from main thread

### DIFF
--- a/Sources/Twift+Authentication.swift
+++ b/Sources/Twift+Authentication.swift
@@ -166,6 +166,7 @@ extension Twift.Authentication {
   ///   - scope: The user access scopes for your authentication. For automatic token refreshing, ensure that `offlineAccess` is included in the scope.
   ///   - presentationContextProvider: Optional presentation context provider. When not provided, this function will handle the presentation context itself.
   /// - Returns: The authenticated user access tokens.
+  @MainActor
   public func authenticateUser(clientId: String,
                                redirectUri: URL,
                                scope: Set<OAuth2Scope>,


### PR DESCRIPTION
Fix for #56. Currently authenticating causes a runtime warning

<img width="866" alt="Screen Shot 2022-10-30 at 10 50 05 AM" src="https://user-images.githubusercontent.com/784999/198885192-85398f99-673e-4289-94d1-5c4bfc4d7f8b.png">
