### PR TITLE
Added scope validation per endpoint

### DIFF
--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -6,6 +6,8 @@ let isTestEnvironment = env == "TEST"
 
 extension Twift {
   // MARK: Internal helper methods
+  
+  /// - Throws: `TwiftError.UnauthorizedForRequiredScopes` if the `self.oauthUser` is not authorized for the scope(s) the `route`-`method` combination requires.
   internal func call<T: Codable>(route: APIRoute,
                                  method: HTTPMethod = .GET,
                                  queryItems: [URLQueryItem] = [],
@@ -102,7 +104,12 @@ extension Twift {
     
     request.httpMethod = method.rawValue
   }
-    
+  
+  /// For the given `APIRoute` and `HTTPMethod`, returns a `Set<OAuth2Scope>` listing the “OAuth 2.0 scopes required by this endpoint” specified in the Twitter API v2 documentation.
+  /// 
+  /// - Parameter route: The API route of the Twitter API v2 endpoint.
+  /// - Parameter method: The HTTP method of the Twitter API v2 endpoint.
+  /// - Returns: A set of scopes required to use the Twitter API v2 endpoint
   internal func requiredScopes(for route: APIRoute, method: HTTPMethod) -> Set<OAuth2Scope> {
     switch method {
       case .GET: return requiredScopesForGETRoute(route)
@@ -112,6 +119,7 @@ extension Twift {
     }
   }
   
+  /// Private helper method for `requiredScopes(for:, method:)`— handles the `HTTPMethod.GET` cases.
   fileprivate func requiredScopesForGETRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
     switch route {
     case .tweet(_),
@@ -167,6 +175,7 @@ extension Twift {
     }
   }
   
+  /// Private helper method for `requiredScopes(for:, method:)`— handles the `HTTPMethod.POST` cases.
   fileprivate func requiredScopesForPOSTRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
     switch route {
     case .tweets(_):
@@ -196,6 +205,7 @@ extension Twift {
     }
   }
   
+  /// /// Private helper method for `requiredScopes(for:, method:)`— handles the `HTTPMethod.PUT` cases.
   fileprivate func requiredScopesForPUTRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
     switch route {
     case .tweetHidden(_):
@@ -207,6 +217,7 @@ extension Twift {
     }
   }
   
+  /// /// Private helper method for `requiredScopes(for:, method:)`— handles the `HTTPMethod.DELETE` cases.
   fileprivate func requiredScopesForDELETERoute(_ route: APIRoute) -> Set<OAuth2Scope> {
     switch route {
     case .tweet(_):

--- a/Sources/Twift+API.swift
+++ b/Sources/Twift+API.swift
@@ -11,6 +11,15 @@ extension Twift {
                                  queryItems: [URLQueryItem] = [],
                                  body: Data? = nil
   ) async throws -> T {
+    if let oauthUser = self.oauthUser {
+      let requiredScopes = requiredScopes(for: route, method: method)
+      guard requiredScopes.isSubset(of: oauthUser.scope) else {
+        throw TwiftError.UnauthorizedForRequiredScopes(requiredScopes,
+          missingScopes: requiredScopes.subtracting(oauthUser.scope)
+        )
+      }
+    }
+    
     if case AuthenticationType.oauth2UserAuth(_, _) = self.authenticationType {
       try await self.refreshOAuth2AccessToken()
     }
@@ -92,6 +101,136 @@ extension Twift {
     }
     
     request.httpMethod = method.rawValue
+  }
+    
+  internal func requiredScopes(for route: APIRoute, method: HTTPMethod) -> Set<OAuth2Scope> {
+    switch method {
+      case .GET: return requiredScopesForGETRoute(route)
+      case .POST: return requiredScopesForPOSTRoute(route)
+      case .PUT: return requiredScopesForPUTRoute(route)
+      case .DELETE: return requiredScopesForDELETERoute(route)
+    }
+  }
+  
+  fileprivate func requiredScopesForGETRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
+    switch route {
+    case .tweet(_),
+          .tweets(_),
+          .timeline(_),
+          .mentions(_),
+          .reverseChronologicalTimeline(_):
+      return [ .tweetRead, .usersRead ]
+    case .users(_),
+          .usersByUsernames(_),
+          .singleUserById(_),
+          .singleUserByUsername(_),
+          .me:
+      return [ .tweetRead, .usersRead ]
+    case .following(_),
+          .followers(_):
+      return [ .tweetRead, .usersRead, .followsRead ]
+    case .blocking(_):
+      return [ .tweetRead, .usersRead, .blockRead ]
+    case .muting(_):
+      return [ .tweetRead, .usersRead, .muteRead ]
+    case .volumeStream,
+          .filteredStream,
+          .filteredStreamRules:
+      return [] // no scopes listed in API docs
+    case .searchRecent:
+      return [ .tweetRead, .usersRead ]
+    case .searchAll:
+      return [] // no scopes listed in API docs; seems to require only Academic Research access
+    case .likingUsers(_),
+          .likedTweets(_):
+      return [ .tweetRead, .usersRead, .likeRead ]
+    case .retweetedBy(_),
+          .quoteTweets(_):
+      return [ .tweetRead, .usersRead ]
+    case .list(_),
+          .userOwnedLists(_),
+          .listTweets(_),
+          .userListMemberships(_),
+          .listMembers(_),
+          .listFollowers(_),
+          .userFollowingLists(_, _),
+          .userPinnedLists(_, _):
+      return [ .tweetRead, .usersRead, .listRead ]
+    case .spaces(_, _),
+          .spacesByCreatorIds,
+          .searchSpaces:
+      return [ .tweetRead, .usersRead, .spaceRead ]
+    case .bookmarks(_):
+      return [ .tweetRead, .usersRead, .bookmarkRead ]
+    default:
+      fatalError("Route \(route) not valid for HTTP GET method.")
+    }
+  }
+  
+  fileprivate func requiredScopesForPOSTRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
+    switch route {
+    case .tweets(_):
+      return  [ .tweetRead, .usersRead, .tweetWrite ]
+    case .following(_):
+      return [ .tweetRead, .usersRead, .followsWrite ]
+    case .blocking(_):
+      return [ .tweetRead, .usersRead, .blockWrite ]
+    case .muting(_):
+      return [ .tweetRead, .usersRead, .muteWrite ]
+    case .filteredStreamRules:
+      return [] // no scopes listed in API docs
+    case .userLikes(_):
+      return [ .tweetRead, .usersRead, .likeWrite ]
+    case .retweets(_, _):
+      return [ .tweetRead, .usersRead, .tweetWrite ]
+    case .listMembers(_),
+          .userFollowingLists(_, _),
+          .userPinnedLists(_, _):
+      return [ .tweetRead, .usersRead, .listWrite ]
+    case .createList:
+      return [ .tweetRead, .usersRead, .listRead, .listWrite ]
+    case .bookmarks(_):
+      return [ .tweetRead, .usersRead, .bookmarkWrite ]
+    default:
+      fatalError("Route \(route) not valid for HTTP POST method.")
+    }
+  }
+  
+  fileprivate func requiredScopesForPUTRoute(_ route: APIRoute) -> Set<OAuth2Scope> {
+    switch route {
+    case .tweetHidden(_):
+      return [ .tweetRead, .usersRead, .tweetModerateWrite ]
+    case .list(_):
+      return [ .tweetRead, .usersRead, .listWrite ]
+    default:
+      fatalError("Route \(route) not valid for HTTP PUT method.")
+    }
+  }
+  
+  fileprivate func requiredScopesForDELETERoute(_ route: APIRoute) -> Set<OAuth2Scope> {
+    switch route {
+    case .tweet(_):
+      return  [ .tweetRead, .usersRead, .tweetWrite ]
+    case .deleteFollow(_, _):
+      return [ .tweetRead, .usersRead, .followsWrite ]
+    case .deleteBlock(_, _):
+      return [ .tweetRead, .usersRead, .blockWrite ]
+    case .deleteMute(_, _):
+      return [ .tweetRead, .usersRead, .muteWrite ]
+    case .deleteUserLikes(_, _):
+      return [ .tweetRead, .usersRead, .likeWrite ]
+    case .retweets(_, _):
+      return [ .tweetRead, .usersRead, .tweetWrite ]
+    case .list(_),
+          .removeListMember(_, _),
+          .userFollowingLists(_, _),
+          .userPinnedLists(_, _):
+      return [ .tweetRead, .usersRead, .listWrite ]
+    case .deleteBookmark(_, _):
+      return [ .tweetRead, .usersRead, .bookmarkWrite ]
+    default:
+      fatalError("Route \(route) not valid for HTTP DELETE method.")
+    }
   }
 }
 

--- a/Sources/Twift+Errors.swift
+++ b/Sources/Twift+Errors.swift
@@ -14,6 +14,9 @@ public enum TwiftError: Error {
   
   /// This error is thrown when the called function expected an integer within a specified range but was passed a value outside that range.
   case RangeOutOfBoundsError(min: Int = 1, max: Int = 1000, fieldName: String, actual: Int)
+  
+  /// This error is thrown when the Twitter endpoint route called requires scopes that the current OAuth2User is not authorized for (Twitter API request would normally result in an HTTP 401 Unauthorized error).
+  case UnauthorizedForRequiredScopes(_ requiredScopes: Set<OAuth2Scope>, missingScopes: Set<OAuth2Scope>)
 }
 
 extension TwiftError: LocalizedError {
@@ -31,6 +34,8 @@ extension TwiftError: LocalizedError {
       return "Unknown Error: \(details.debugDescription)"
     case .RangeOutOfBoundsError(let min, let max, let fieldName, let actual):
       return "Expected a value between \(min) and \(max) for field \"\(fieldName)\" but got \(actual)"
+    case .UnauthorizedForRequiredScopes(let requiredScopes, let missingScopes):
+      return "Twitter endpoint route requires scopes \(requiredScopes); authorization missing scopes \(missingScopes)."
     }
   }
 }


### PR DESCRIPTION
Added scope validation per endpoint, based on the “OAuth 2.0 scopes required by this endpoint” section listed for each endpoint in the Twitter API v2 docs (https://developer.twitter.com/en/docs/twitter-api).

Motivation for this addition is that if you're not using a scope of `Set(OAuth2Scope.allCases)` when authentication with OAuth2, it can be easy to call an endpoint you don't have the proper scope for and only get back a `TwitterAPIError` with a non-specific HTTP 401 Unauthorized message (same error you'd get if you weren't properly authenticated), which can be confusing for 1st-time users of Twift setting things up in their app.  Further, since the call to `Twift.Authentication().authenticateUser(…, scope: …, …)` and the call to a `twiftClient.get…()` endpoint often live in different files in app code, it's not obvious where the issue is.

This addition checks the `OAuth2User`'s scopes against the required scopes for the Twitter endpoint (`APIRoute` + `HTTPMethod`), via new internal `requiredScopes(for:APIRoute,method:HTTPMethod) -> Set<OAuth2Scope>` helper method.  The result (in a failure state) is that the client app will get a (new) specific `TwiftError.UnauthorizedForRequiredScopes(_:,missingScopes:)` exception instead of a generic HTTP 401 `TwitterAPIError` _without actually making the invalid call to the Twitter API._  I also considered doing this check in `decodeOrThrow<…>(…)` (where `TwitterAPIError` is thrown from) only after we get a 401 back from the Twitter API, but decided that a more immediate exception and avoiding hitting Twitter with invalid requests is probably better overall.

* At the beginning of `call<>(route:,method:,queryItems:,body:)`, now checking if the `requiredScopes` for this endpoint (`route` + `method`) is a subset of the current `oauthUser.scope`.  If not, throwing a `TwiftError.UnauthorizedForRequiredScopes`. 
* Created new internal util method `requiredScopes(for route: APIRoute, method: HTTPMethod)` which returns a `Set<OAuth2Scope>` containing all the required scopes for the endpoint.  
	‣ Uses calls to new HTTP-method-specific `requiredScopesFor…Route()` util methods to produce the return value.
* Created new fileprivate HTTP-method-specific helper methods `requiredScopesForGET`/`POST`/`PUT`/`DELETERoute(_ route: APIRoute)` which switch on the `route` returning the API doc-specified `Set<OAuth2Scope>` list for all valid routes, and defaulting to emitting a `fatalError(…)` if the `route` is not valid for that method.  
	‣ Decided to `fatalError(…)` instead of throwing a Swift error because a missing route would be an issue in Twift's code, not app client code— so an error we're guaranteed to see in Twift's Tests.
* Added new `TwiftError.UnauthorizedForRequiredScopes(_ requiredScopes: Set<OAuth2Scope>, missingScopes: Set<OAuth2Scope>)` error.
*  Added doc comments to new requiredScopes…(…) methods and `call<…>(…)` method